### PR TITLE
Fixed https://github.com/alibaba/macaca/issues/714

### DIFF
--- a/lib/android.js
+++ b/lib/android.js
@@ -45,7 +45,7 @@ exports.dumpXMLAndScreenShot = function *() {
     return node;
   };
 
-  var origin = _.filter(hierarchy.node, i => i.package !== 'com.android.systemui');
+  var origin = _.filter(hierarchy.node, i => i !== null && typeof i === 'object' && i.package !== 'com.android.systemui');
   var data = adaptor(origin[0]);
   fs.writeFileSync(xmlFilePath, JSON.stringify(data), 'utf8');
   const remoteFile = `${ADB.ANDROID_TMP_DIR}/screenshot.png`;


### PR DESCRIPTION
Explanation:

The hierarchy object obtained from Android API 18-21 devices is different from devices running API 22 or above, as there are some noise strings and arrays preceding the actual desired json data. 

The fix is basically filtering out those noises.